### PR TITLE
Distribute static files via package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-from glob import glob
 
 setuptools.setup(
     name="nbresuse",
@@ -12,7 +11,5 @@ setuptools.setup(
         'psutil',
         'notebook',
     ],
-    data_files=[
-        ('share/jupyter/nbextensions/nbresuse', glob('nbresuse/static/*'))
-    ]
+    package_data={'nbresuse': ['static/*']},
 )


### PR DESCRIPTION
Running `jupyter nbextension install --py nbresuse` expected to find main.js in /opt/conda/lib/python3.5/site-packages/nbresuse/static, but main.js was in /opt/conda/share/jupyter/nbextensions/nbresuse/. With the above change, the nbextension command succeeds.