### PR TITLE
Handle case of memory limit not set.

### DIFF
--- a/nbresuse/handlers.py
+++ b/nbresuse/handlers.py
@@ -8,10 +8,13 @@ def get_metrics():
     cur_process = psutil.Process()
     all_processes = [cur_process] + cur_process.children(recursive=True)
     rss = sum([p.memory_info().rss for p in all_processes])
+    mem_limit = os.environ.get('MEM_LIMIT', None)
+    if mem_limit is not None:
+        mem_limit = int(mem_limit)
     return {
         'rss': rss,
         'limits': {
-            'memory': int(os.environ.get('MEM_LIMIT', None))
+            'memory': mem_limit
         }
     }
 


### PR DESCRIPTION
If the memory limit isn't set, the server extension raises an exception by doing `int(None`). This fixes it.