### PR TITLE
Don't poll server when page is not active

### DIFF
--- a/nbresuse/static/main.js
+++ b/nbresuse/static/main.js
@@ -21,6 +21,10 @@ define(['jquery', 'base/js/utils'], function ($, utils) {
     }
 
     var displayMetrics = function() {
+        if (document.hidden) {
+            // Don't poll when nobody is looking
+            return;
+        }
         $.getJSON(utils.get_body_data('baseUrl') + 'metrics', function(data) {
             // FIXME: Proper setups for MB and GB. MB should have 0 things
             // after the ., but GB should have 2.
@@ -48,6 +52,14 @@ define(['jquery', 'base/js/utils'], function ($, utils) {
         displayMetrics();
         // Update every five seconds, eh?
         setInterval(displayMetrics, 1000 * 5);
+
+        document.addEventListener("visibilitychange", function() {
+            // Update instantly when user activates notebook tab
+            // FIXME: Turn off update timer completely when tab not in focus
+            if (!document.hidden) {
+                displayMetrics();
+            }
+        }, false);
     };
 
     return {

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="nbresuse",
-    version='0.3.0',
+    version='0.3.1',
     url="https://github.com/yuvipanda/nbresuse",
     author="Yuvi Panda",
     description="Simple Jupyter extension to show how much resources (RAM) your notebook is using",


### PR DESCRIPTION
- Don't poll in background, since user does not see it
- Poll instantly once page is foregrounded

This should reduce the number of /metrics requests massively,
with minimal interruption to user experience.