### PR TITLE
Make psutil optional dependency of NBResuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.ipynb

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ main toolbar in the notebook itself, refreshing every 5s.
 You can currently install this package from PyPI.
 
 ```bash
-pip install nbresuse
+pip install nbresuse[resources]
 ```
+
+The above command will install NBResuse along with `psutil` Python package (which is used for getting hardware usage information from the system). If you would like to install NBResuse _without_ `psutil` (in which case NBResuse does essentially nothing), run `pip install nbresuse` instead.
 
 **If your notebook version is < 5.3**, you need to enable the extension manually.
 

--- a/nbresuse/metrics.py
+++ b/nbresuse/metrics.py
@@ -1,6 +1,9 @@
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None
 
 
 class MemoryMetrics(NamedTuple):
@@ -13,30 +16,38 @@ class CPUMetrics(NamedTuple):
     cpu_usage: float
 
 
-def memory_metrics() -> MemoryMetrics:
-    cur_process = psutil.Process()
-    all_processes = [cur_process] + cur_process.children(recursive=True)
+def memory_metrics() -> Optional[MemoryMetrics]:
+    if psutil:
+        cur_process = psutil.Process()
+        all_processes = [cur_process] + cur_process.children(recursive=True)
 
-    rss = sum([p.memory_info().rss for p in all_processes])
-    virtual_memory = psutil.virtual_memory()
+        rss = sum([p.memory_info().rss for p in all_processes])
+        virtual_memory = psutil.virtual_memory().total
 
-    return MemoryMetrics(rss, virtual_memory.total)
+    else:
+        return None
+
+    return MemoryMetrics(rss, virtual_memory)
 
 
-def cpu_metrics() -> CPUMetrics:
-    cur_process = psutil.Process()
-    all_processes = [cur_process] + cur_process.children(recursive=True)
+def cpu_metrics() -> Optional[CPUMetrics]:
+    if psutil:
+        cur_process = psutil.Process()
+        all_processes = [cur_process] + cur_process.children(recursive=True)
 
-    cpu_count = psutil.cpu_count()
+        cpu_count = psutil.cpu_count()
 
-    def get_cpu_percent(p):
-        try:
-            return p.cpu_percent(interval=0.05)
-        # Avoid littering logs with stack traces complaining
-        # about dead processes having no CPU usage
-        except BaseException:
-            return 0
+        def get_cpu_percent(p):
+            try:
+                return p.cpu_percent(interval=0.05)
+            # Avoid littering logs with stack traces complaining
+            # about dead processes having no CPU usage
+            except BaseException:
+                return 0
 
-    cpu_percent = sum([get_cpu_percent(p) for p in all_processes])
+        cpu_percent = sum([get_cpu_percent(p) for p in all_processes])
+
+    else:
+        return None
 
     return CPUMetrics(cpu_count * 100.0, cpu_percent)

--- a/nbresuse/static/main.js
+++ b/nbresuse/static/main.js
@@ -61,7 +61,7 @@ define([
                 let totalMemoryUsage = metric("total_memory_usage", data);
                 let maxMemoryUsage = metric("max_memory_usage", data);
 
-                if (!totalMemoryUsage || !maxMemoryUsage)
+                if (maxMemoryUsage[2] <= 0)
                     return;
                 totalMemoryUsage = humanFileSize(parseFloat(totalMemoryUsage[2]));
                 maxMemoryUsage = humanFileSize(parseFloat(maxMemoryUsage[2]));

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
     name="nbresuse",
-    version="0.3.3",
+    version="0.3.4",
     url="https://github.com/yuvipanda/nbresuse",
     author="Yuvi Panda",
     description="Simple Jupyter extension to show how much resources (RAM) your notebook is using",
@@ -23,9 +23,10 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
     ],
     packages=setuptools.find_packages(),
-    install_requires=["psutil>=5.6.0", "notebook>=5.6.0"],
+    install_requires=["notebook>=5.6.0", "prometheus_client"],
     extras_require={
-        "dev": ["autopep8", "pytest", "flake8", "pytest-cov>=2.6.1", "mock"]
+        "resources": ["psutil>=5.6.0"],
+        "dev": ["autopep8", "pytest", "flake8", "pytest-cov>=2.6.1", "mock"],
     },
     data_files=[
         ("share/jupyter/nbextensions/nbresuse", glob("nbresuse/static/*")),


### PR DESCRIPTION
Try to make `psutil` import optional. Still need to implement fronted fallback behavior if no `psutil` is found. (Or rather, need to better understand how JupyterLab statusbar looks for NBResuse output, to make sure that NBResuse "does nothing" in the way that JupyterLab expects when psutil is not installed.)