### PR TITLE
Setting up testing/a few cleanup items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # nbresuse
+[![Build Status](https://dev.azure.com/tpaine154/jupyter/_apis/build/status/timkpaine.nbresuse?branchName=master)](https://dev.azure.com/tpaine154/jupyter/_build/latest?definitionId=17&branchName=master)
+[![Coverage](https://img.shields.io/azure-devops/coverage/tpaine154/jupyter/17)](https://dev.azure.com/tpaine154/jupyter/_build?definitionId=17&_a=summary)
+[![PyPI](https://img.shields.io/pypi/l/nbresuse.svg)](https://pypi.python.org/pypi/nbresuse)
+[![PyPI](https://img.shields.io/pypi/v/nbresuse.svg)](https://pypi.python.org/pypi/nbresuse)
+
+
 
 ![Screenshot with memory limit](screenshot.png)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,128 @@
+trigger:
+- master
+
+jobs:
+- job: 'Linux'
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+      displayName: 'Use Python $(python.version)'
+
+    - script: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+      displayName: 'Install dependencies'
+
+    - script: |
+        python -m flake8 nbresuse
+      displayName: 'Lint'
+
+    - script:
+        python -m pytest -vvv nbresuse --cov=nbresuse --junitxml=python_junit.xml --cov-report=xml --cov-branch
+      displayName: 'Test'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: 'python_junit.xml'
+        testRunTitle: 'Publish test results for Python $(python.version) $(manylinux_flag)'
+
+    - task: PublishCodeCoverageResults@1
+      inputs: 
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/*coverage.xml'
+
+- job: 'Mac'
+  pool:
+    vmImage: 'macos-10.14'
+
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+      displayName: 'Use Python $(python.version)'
+
+    - script: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+      displayName: 'Install dependencies'
+
+    - script: |
+        python -m flake8 nbresuse
+      displayName: 'Lint'
+
+    - script: |
+        python -m pytest -vvv nbresuse --cov=nbresuse --junitxml=python_junit.xml --cov-report=xml --cov-branch
+      displayName: 'Test'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: 'python_junit.xml'
+        testRunTitle: 'Publish test results for Python $(python.version) $(manylinux_flag)'
+
+    - task: PublishCodeCoverageResults@1
+      inputs: 
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/*coverage.xml'
+
+- job: 'Windows'
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+      displayName: 'Use Python $(python.version)'
+
+    - script: |
+        which python > python.txt
+        set /p PYTHON=<python.txt
+        ln -s %PYTHON% %PYTHON%$(python.version)
+        python --version
+        which python$(python.version)
+      displayName: "Which python"
+
+    - script: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+      displayName: 'Install dependencies'
+
+    - script: |
+        python -m flake8 nbresuse
+      displayName: 'Lint'
+
+    - script: |
+        python -m pytest -vvv nbresuse --cov=nbresuse --junitxml=python_junit.xml --cov-report=xml --cov-branch
+      displayName: 'Test'
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: 'python_junit.xml'
+        testRunTitle: 'Publish test results for Python $(python.version) $(manylinux_flag)'
+
+    - task: PublishCodeCoverageResults@1
+      inputs: 
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/*coverage.xml'

--- a/nbresuse/metrics.py
+++ b/nbresuse/metrics.py
@@ -37,7 +37,7 @@ def cpu_metrics() -> CPUMetrics:
             return p.cpu_percent(interval=0.05)
         # Avoid littering logs with stack traces complaining
         # about dead processes having no CPU usage
-        except:
+        except BaseException:
             return 0
     cpu_percent = sum([get_cpu_percent(p) for p in all_processes])
 

--- a/nbresuse/tests/test_basic.py
+++ b/nbresuse/tests/test_basic.py
@@ -1,0 +1,41 @@
+from mock import MagicMock, patch
+
+
+class TestBasic:
+    '''Some basic tests, checking import, making sure APIs remain consistent, etc'''
+
+    def test_import_serverextension(self):
+        '''Check that serverextension hooks are available'''
+        from nbresuse import _jupyter_server_extension_paths, \
+            _jupyter_nbextension_paths, \
+            load_jupyter_server_extension
+
+        assert _jupyter_server_extension_paths() == [{'module': 'nbresuse'}]
+        assert _jupyter_nbextension_paths() == [{
+            "section": "notebook",
+            "dest": "nbresuse",
+            "src": "static",
+            "require": "nbresuse/main"
+        }]
+
+        # mock a notebook app
+        nbapp_mock = MagicMock()
+        nbapp_mock.web_app.settings = {}
+
+        # mock these out for unit test
+        with patch('tornado.ioloop.PeriodicCallback') as periodic_callback_mock, \
+                patch('nbresuse.ResourceUseDisplay') as resource_use_display_mock, \
+                patch('nbresuse.PrometheusHandler') as prometheus_handler_mock:
+
+            # load up with mock
+            load_jupyter_server_extension(nbapp_mock)
+
+            # assert that we installed the application in settings
+            print(nbapp_mock.web_app.settings)
+            assert 'nbresuse_display_config' in nbapp_mock.web_app.settings
+
+            # assert that we instantiated a periodic callback with the fake
+            # prometheus
+            assert periodic_callback_mock.return_value.start.call_count == 1
+            assert prometheus_handler_mock.call_count == 1
+            prometheus_handler_mock.assert_called_with(nbapp_mock)

--- a/nbresuse/utils.py
+++ b/nbresuse/utils.py
@@ -2,6 +2,8 @@ from traitlets import TraitType
 import six
 
 # copy-pasted from the master of Traitlets source
+
+
 class Callable(TraitType):
     """A trait which is callable.
     Notes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[bdist_wheel]
+universal=1
+
+[metadata]
+description_file = README.md
+
+[flake8]
+max-line-length=200
+exclude=nbresuse/tests

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,16 @@ setuptools.setup(
     description="Simple Jupyter extension to show how much resources (RAM) your notebook is using",
     packages=setuptools.find_packages(),
     install_requires=[
-        'psutil',
-        'notebook',
+        'psutil>=5.6.0',
+        'notebook>=5.6.0',
     ],
+    extras_require={
+        'dev': ['autopep8',
+                'pytest',
+                'flake8',
+                'pytest-cov>=2.6.1',
+                'mock']
+    },
     data_files=[
         ('share/jupyter/nbextensions/nbresuse', glob('nbresuse/static/*')),
         ('etc/jupyter/jupyter_notebook_config.d', ['nbresuse/etc/serverextension.json']),


### PR DESCRIPTION
This PR does a few things

- sets up testing for python3.7 on linux/osx/windows
    - just did this on my account, we'll need to set it up for the main
    - do we want to add more python versions?
- pins `psutil` and `notebook` dependencies
- `autopep8`'d for `flake8` compatibility
- adding test folder, some first tests
- adds testing, coverage, license, and version badges to the readme (need to point away from my azure as well)


