### PR TITLE
Include LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
This came up while packaging `nbresuse` for conda here: https://github.com/conda-forge/staged-recipes/pull/10854

We can bundle the license in the sdist to it wouldn't need to the copied into the feedstock anymore.