### PR TITLE
Make NBResuse more flexible.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,10 @@ We recommend using [pipenv](https://docs.pipenv.org/) to make development easier
 4. Do a dev install of nbresuse and its dependencies
 
    ```bash
-   pip install --editable .
+   pip install --editable .[resources]
    ```
+
+   To test the behavior of NBResuse without `psutil` installed, run `pip install --editable .` instead.
 
 5. Install and enable the nbextension for use with Jupyter Classic Notebook.
 

--- a/nbresuse/__init__.py
+++ b/nbresuse/__init__.py
@@ -93,7 +93,8 @@ class ResourceUseDisplay(Configurable):
         """,
     ).tag(config=True)
 
-    cpu_limit = Float(
+    cpu_limit = Union(
+        trait_types=[Float(), Callable()],
         default_value=0,
         help="""
         CPU usage limit to display to the user.

--- a/nbresuse/metrics.py
+++ b/nbresuse/metrics.py
@@ -1,86 +1,81 @@
-from typing import NamedTuple
-from typing import Optional
-
 try:
     import psutil
 except ImportError:
     psutil = None
 
-
-class MemoryMetrics(NamedTuple):
-    rss: int
-    virtual_memory: int
+from notebook.notebookapp import NotebookApp
 
 
-class CPUMetrics(NamedTuple):
-    cpu_percent: float
-    cpu_count: int
+class PSUtilMetricsLoader:
+    def __init__(self, nbapp: NotebookApp):
+        self.config = nbapp.web_app.settings["nbresuse_display_config"]
+        self.nbapp = nbapp
 
+    def process_metric(self, name, kwargs={}, attribute=None):
+        if psutil is None:
+            return None
+        else:
+            current_process = psutil.Process()
+            all_processes = [current_process] + current_process.children(recursive=True)
 
-def per_process_metric(metric_name, metric_kwargs={}, metric_attribute=None):
-    if psutil is None:
-        return None
-    else:
-        current_process = psutil.Process()
-        all_processes = [current_process] + current_process.children(recursive=True)
+            def get_process_metric(process, name, kwargs, attribute=None):
+                try:
+                    # psutil.Process methods will either return...
+                    metric_value = getattr(process, name)(**kwargs)
+                    if attribute is not None:  # ... a named tuple
+                        return getattr(metric_value, attribute)
+                    else:  # ... or a number
+                        return metric_value
+                # Avoid littering logs with stack traces
+                # complaining about dead processes
+                except BaseException:
+                    return 0
 
-        def get_per_process_metric(
-            process, metric_name, metric_kwargs, metric_attribute=None
-        ):
-            try:
-                metric_value = getattr(process, metric_name)(**metric_kwargs)
-                if metric_attribute is not None:
-                    return getattr(metric_value, metric_attribute)
+            process_metric_value = lambda process: get_process_metric(
+                process, name, kwargs, attribute
+            )
+
+            return sum([process_metric_value(process) for process in all_processes])
+
+    def system_metric(self, name, kwargs={}, attribute=None):
+        if psutil is None:
+            return None
+        else:
+            # psutil functions will either return...
+            metric_value = getattr(psutil, name)(**kwargs)
+            if attribute is not None:  # ... a named tuple
+                return getattr(metric_value, attribute)
+            else:  # ... or a number
                 return metric_value
-            # Avoid littering logs with stack traces
-            # complaining about dead processes
-            except BaseException:
-                return 0
 
-        per_process_metric_value = lambda process: get_per_process_metric(
-            process, metric_name, metric_kwargs, metric_attribute
+    def get_metric_values(self, metrics, metric_type):
+        metric_types = {"process": self.process_metric, "system": self.system_metric}
+        metric_value = metric_types[metric_type]  # Switch statement
+
+        metric_values = {}
+        for metric in metrics:
+            name = metric["name"]
+            if metric.get("attribute", False):
+                name += "_" + metric.get("attribute")
+            metric_values.update({name: metric_value(**metric)})
+        return metric_values
+
+    def metrics(self, process_metrics, system_metrics):
+
+        metric_values = self.get_metric_values(process_metrics, "process")
+        metric_values.update(self.get_metric_values(system_metrics, "system"))
+
+        if any(value is None for value in metric_values.values()):
+            return None
+
+        return metric_values
+
+    def memory_metrics(self):
+        return self.metrics(
+            self.config.process_memory_metrics, self.config.system_memory_metrics
         )
 
-        return sum([per_process_metric_value(process) for process in all_processes])
-
-
-def system_metric(metric_name, metric_kwargs={}, metric_attribute=None):
-    if psutil is None:
-        return None
-    else:
-        metric_value = getattr(psutil, metric_name)(**metric_kwargs)
-        if metric_attribute is not None:
-            return getattr(metric_value, metric_attribute)
-        return metric_attribute
-
-
-def memory_metrics() -> Optional[MemoryMetrics]:
-
-    rss = {"metric_name": "memory_info", "metric_attribute": "rss"}
-    rss_value = per_process_metric(**rss)
-
-    virtual_memory = {"metric_name": "virtual_memory", "metric_attribute": "total"}
-    virtual_memory_value = system_metric(**virtual_memory)
-
-    memory_metric_values = {"rss": rss_value, "virtual_memory": virtual_memory_value}
-
-    if any(value is None for value in memory_metric_values.values()):
-        return None
-
-    return MemoryMetrics(**memory_metric_values)
-
-
-def cpu_metrics() -> Optional[CPUMetrics]:
-
-    cpu_percent = {"metric_name": "cpu_percent", "metric_kwargs": {"interval": 0.05}}
-    cpu_percent_value = per_process_metric(**cpu_percent)
-
-    cpu_count = {"metric_name": "cpu_count"}
-    cpu_count_value = system_metric(**cpu_count)
-
-    cpu_metric_values = {"cpu_percent": cpu_percent_value, "cpu_count": cpu_count_value}
-
-    if any(value is None for value in cpu_metric_values.values()):
-        return None
-
-    return CPUMetrics(**cpu_metric_values)
+    def cpu_metrics(self):
+        return self.metrics(
+            self.config.process_cpu_metrics, self.config.system_cpu_metrics
+        )

--- a/nbresuse/metrics.py
+++ b/nbresuse/metrics.py
@@ -1,4 +1,5 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple
+from typing import Optional
 
 try:
     import psutil
@@ -7,47 +8,79 @@ except ImportError:
 
 
 class MemoryMetrics(NamedTuple):
-    current_memory: int
-    max_memory: int
+    rss: int
+    virtual_memory: int
 
 
 class CPUMetrics(NamedTuple):
-    cpu_max: float
-    cpu_usage: float
+    cpu_percent: float
+    cpu_count: int
 
 
-def memory_metrics() -> Optional[MemoryMetrics]:
-    if psutil:
-        cur_process = psutil.Process()
-        all_processes = [cur_process] + cur_process.children(recursive=True)
-
-        rss = sum([p.memory_info().rss for p in all_processes])
-        virtual_memory = psutil.virtual_memory().total
-
-    else:
+def per_process_metric(metric_name, metric_kwargs={}, metric_attribute=None):
+    if psutil is None:
         return None
+    else:
+        current_process = psutil.Process()
+        all_processes = [current_process] + current_process.children(recursive=True)
 
-    return MemoryMetrics(rss, virtual_memory)
-
-
-def cpu_metrics() -> Optional[CPUMetrics]:
-    if psutil:
-        cur_process = psutil.Process()
-        all_processes = [cur_process] + cur_process.children(recursive=True)
-
-        cpu_count = psutil.cpu_count()
-
-        def get_cpu_percent(p):
+        def get_per_process_metric(
+            process, metric_name, metric_kwargs, metric_attribute=None
+        ):
             try:
-                return p.cpu_percent(interval=0.05)
-            # Avoid littering logs with stack traces complaining
-            # about dead processes having no CPU usage
+                metric_value = getattr(process, metric_name)(**metric_kwargs)
+                if metric_attribute is not None:
+                    return getattr(metric_value, metric_attribute)
+                return metric_value
+            # Avoid littering logs with stack traces
+            # complaining about dead processes
             except BaseException:
                 return 0
 
-        cpu_percent = sum([get_cpu_percent(p) for p in all_processes])
+        per_process_metric_value = lambda process: get_per_process_metric(
+            process, metric_name, metric_kwargs, metric_attribute
+        )
 
+        return sum([per_process_metric_value(process) for process in all_processes])
+
+
+def system_metric(metric_name, metric_kwargs={}, metric_attribute=None):
+    if psutil is None:
+        return None
     else:
+        metric_value = getattr(psutil, metric_name)(**metric_kwargs)
+        if metric_attribute is not None:
+            return getattr(metric_value, metric_attribute)
+        return metric_attribute
+
+
+def memory_metrics() -> Optional[MemoryMetrics]:
+
+    rss = {"metric_name": "memory_info", "metric_attribute": "rss"}
+    rss_value = per_process_metric(**rss)
+
+    virtual_memory = {"metric_name": "virtual_memory", "metric_attribute": "total"}
+    virtual_memory_value = system_metric(**virtual_memory)
+
+    memory_metric_values = {"rss": rss_value, "virtual_memory": virtual_memory_value}
+
+    if any(value is None for value in memory_metric_values.values()):
         return None
 
-    return CPUMetrics(cpu_count * 100.0, cpu_percent)
+    return MemoryMetrics(**memory_metric_values)
+
+
+def cpu_metrics() -> Optional[CPUMetrics]:
+
+    cpu_percent = {"metric_name": "cpu_percent", "metric_kwargs": {"interval": 0.05}}
+    cpu_percent_value = per_process_metric(**cpu_percent)
+
+    cpu_count = {"metric_name": "cpu_count"}
+    cpu_count_value = system_metric(**cpu_count)
+
+    cpu_metric_values = {"cpu_percent": cpu_percent_value, "cpu_count": cpu_count_value}
+
+    if any(value is None for value in cpu_metric_values.values()):
+        return None
+
+    return CPUMetrics(**cpu_metric_values)

--- a/nbresuse/prometheus.py
+++ b/nbresuse/prometheus.py
@@ -2,12 +2,8 @@ from typing import Optional
 
 from notebook.notebookapp import NotebookApp
 from prometheus_client import Gauge
-from tornado import gen
 
-from nbresuse.metrics import cpu_metrics
-from nbresuse.metrics import CPUMetrics
-from nbresuse.metrics import memory_metrics
-from nbresuse.metrics import MemoryMetrics
+from nbresuse.metrics import PSUtilMetricsLoader
 
 try:
     # Traitlets >= 4.3.3
@@ -17,10 +13,11 @@ except ImportError:
 
 
 class PrometheusHandler(Callable):
-    def __init__(self, nbapp: NotebookApp):
+    def __init__(self, metricsloader: PSUtilMetricsLoader):
         super().__init__()
-        self.config = nbapp.web_app.settings["nbresuse_display_config"]
-        self.session_manager = nbapp.session_manager
+        self.metricsloader = metricsloader
+        self.config = metricsloader.config
+        self.session_manager = metricsloader.nbapp.session_manager
 
         self.TOTAL_MEMORY_USAGE = Gauge(
             "total_memory_usage", "counter for total memory usage", []
@@ -34,40 +31,39 @@ class PrometheusHandler(Callable):
         )
         self.MAX_CPU_USAGE = Gauge("max_cpu_usage", "counter for max cpu usage", [])
 
-    @gen.coroutine
-    def __call__(self, *args, **kwargs):
-        memory_metric_values = memory_metrics()
+    async def __call__(self, *args, **kwargs):
+        memory_metric_values = self.metricsloader.memory_metrics()
         if memory_metric_values is not None:
-            self.TOTAL_MEMORY_USAGE.set(memory_metric_values.rss)
+            self.TOTAL_MEMORY_USAGE.set(memory_metric_values["memory_info_rss"])
             self.MAX_MEMORY_USAGE.set(self.apply_memory_limit(memory_metric_values))
         if self.config.track_cpu_percent:
-            cpu_metric_values = cpu_metrics()
+            cpu_metric_values = self.metricsloader.cpu_metrics()
             if cpu_metric_values is not None:
-                self.TOTAL_CPU_USAGE.set(cpu_metric_values.cpu_percent)
+                self.TOTAL_CPU_USAGE.set(cpu_metric_values["cpu_percent"])
                 self.MAX_CPU_USAGE.set(self.apply_cpu_limit(cpu_metric_values))
 
-    def apply_memory_limit(
-        self, memory_metric_values: Optional[MemoryMetrics]
-    ) -> Optional[int]:
+    def apply_memory_limit(self, memory_metric_values) -> Optional[int]:
         if memory_metric_values is None:
             return None
         else:
             if callable(self.config.mem_limit):
-                return self.config.mem_limit(rss=memory_metric_values.rss)
+                return self.config.mem_limit(
+                    rss=memory_metric_values["memory_info_rss"]
+                )
             elif self.config.mem_limit > 0:  # mem_limit is an Int
                 return self.config.mem_limit
             else:
-                return memory_metric_values.virtual_memory
+                return memory_metric_values["virtual_memory_total"]
 
-    def apply_cpu_limit(
-        self, cpu_metric_values: Optional[CPUMetrics]
-    ) -> Optional[float]:
+    def apply_cpu_limit(self, cpu_metric_values) -> Optional[float]:
         if cpu_metric_values is None:
             return None
         else:
             if callable(self.config.cpu_limit):
-                return self.config.cpu_limit(cpu_percent=cpu_metric_values.cpu_percent)
+                return self.config.cpu_limit(
+                    cpu_percent=cpu_metric_values["cpu_percent"]
+                )
             elif self.config.cpu_limit > 0.0:  # cpu_limit is a Float
                 return self.config.cpu_limit
             else:
-                return 100.0 * cpu_metric_values.cpu_count
+                return 100.0 * cpu_metric_values["cpu_count"]

--- a/nbresuse/prometheus.py
+++ b/nbresuse/prometheus.py
@@ -1,7 +1,8 @@
+from typing import Optional
+
 from notebook.notebookapp import NotebookApp
 from prometheus_client import Gauge
 from tornado import gen
-from typing import Optional
 
 from nbresuse.metrics import cpu_metrics
 from nbresuse.metrics import CPUMetrics
@@ -14,14 +15,6 @@ try:
 except ImportError:
     from .utils import Callable
 
-TOTAL_MEMORY_USAGE = Gauge("total_memory_usage", "counter for total memory usage", [])
-
-MAX_MEMORY_USAGE = Gauge("max_memory_usage", "counter for max memory usage", [])
-
-TOTAL_CPU_USAGE = Gauge("total_cpu_usage", "counter for total cpu usage", [])
-
-MAX_CPU_USAGE = Gauge("max_cpu_usage", "counter for max cpu usage", [])
-
 
 class PrometheusHandler(Callable):
     def __init__(self, nbapp: NotebookApp):
@@ -29,30 +22,52 @@ class PrometheusHandler(Callable):
         self.config = nbapp.web_app.settings["nbresuse_display_config"]
         self.session_manager = nbapp.session_manager
 
+        self.TOTAL_MEMORY_USAGE = Gauge(
+            "total_memory_usage", "counter for total memory usage", []
+        )
+        self.MAX_MEMORY_USAGE = Gauge(
+            "max_memory_usage", "counter for max memory usage", []
+        )
+
+        self.TOTAL_CPU_USAGE = Gauge(
+            "total_cpu_usage", "counter for total cpu usage", []
+        )
+        self.MAX_CPU_USAGE = Gauge("max_cpu_usage", "counter for max cpu usage", [])
+
     @gen.coroutine
     def __call__(self, *args, **kwargs):
-        metrics = self.apply_memory_limits(memory_metrics())
-        if metrics is not None:
-            TOTAL_MEMORY_USAGE.set(metrics.current_memory)
-            MAX_MEMORY_USAGE.set(metrics.max_memory)
+        memory_metric_values = memory_metrics()
+        if memory_metric_values is not None:
+            self.TOTAL_MEMORY_USAGE.set(memory_metric_values.rss)
+            self.MAX_MEMORY_USAGE.set(self.apply_memory_limit(memory_metric_values))
         if self.config.track_cpu_percent:
-            metrics = self.apply_cpu_limits(cpu_metrics())
-            if metrics is not None:
-                TOTAL_CPU_USAGE.set(metrics.cpu_usage)
-                MAX_CPU_USAGE.set(metrics.cpu_max)
+            cpu_metric_values = cpu_metrics()
+            if cpu_metric_values is not None:
+                self.TOTAL_CPU_USAGE.set(cpu_metric_values.cpu_percent)
+                self.MAX_CPU_USAGE.set(self.apply_cpu_limit(cpu_metric_values))
 
-    def apply_memory_limits(self, metrics: Optional[MemoryMetrics]) -> Optional[MemoryMetrics]:
-        if metrics is not None:
+    def apply_memory_limit(
+        self, memory_metric_values: Optional[MemoryMetrics]
+    ) -> Optional[int]:
+        if memory_metric_values is None:
+            return None
+        else:
             if callable(self.config.mem_limit):
-                metrics.max_memory = self.config.mem_limit(rss=metrics.current_memory)
+                return self.config.mem_limit(rss=memory_metric_values.rss)
             elif self.config.mem_limit > 0:  # mem_limit is an Int
-                metrics.max_memory = self.config.mem_limit
-        return metrics
+                return self.config.mem_limit
+            else:
+                return memory_metric_values.virtual_memory
 
-    def apply_cpu_limits(self, metrics: Optional[CPUMetrics]) -> Optional[CPUMetrics]:
-        if metrics is not None:
+    def apply_cpu_limit(
+        self, cpu_metric_values: Optional[CPUMetrics]
+    ) -> Optional[float]:
+        if cpu_metric_values is None:
+            return None
+        else:
             if callable(self.config.cpu_limit):
-                metrics.cpu_max = self.config.cpu_limit(cpu_percent=metrics.cpu_usage)
+                return self.config.cpu_limit(cpu_percent=cpu_metric_values.cpu_percent)
             elif self.config.cpu_limit > 0.0:  # cpu_limit is a Float
-                metrics.cpu_max = self.config.cpu_limit
-        return metrics
+                return self.config.cpu_limit
+            else:
+                return 100.0 * cpu_metric_values.cpu_count

--- a/nbresuse/prometheus.py
+++ b/nbresuse/prometheus.py
@@ -44,13 +44,15 @@ class PrometheusHandler(Callable):
     def apply_memory_limits(self, metrics: Optional[MemoryMetrics]) -> Optional[MemoryMetrics]:
         if metrics is not None:
             if callable(self.config.mem_limit):
-                metrics.max_memory = self.config.mem_limit(rss=metrics.max_memory)
+                metrics.max_memory = self.config.mem_limit(rss=metrics.current_memory)
             elif self.config.mem_limit > 0:  # mem_limit is an Int
                 metrics.max_memory = self.config.mem_limit
         return metrics
 
     def apply_cpu_limits(self, metrics: Optional[CPUMetrics]) -> Optional[CPUMetrics]:
         if metrics is not None:
-            if self.config.cpu_limit > 0:
+            if callable(self.config.cpu_limit):
+                metrics.cpu_max = self.config.cpu_limit(cpu_percent=metrics.cpu_usage)
+            elif self.config.cpu_limit > 0.0:  # cpu_limit is a Float
                 metrics.cpu_max = self.config.cpu_limit
         return metrics

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
     name="nbresuse",
-    version="0.3.4",
+    version="0.4.0",
     url="https://github.com/yuvipanda/nbresuse",
     author="Yuvi Panda",
     description="Simple Jupyter extension to show how much resources (RAM) your notebook is using",


### PR DESCRIPTION
First change is to make CPU limit also callable, and thus have almost identical patterns for memory and CPU metrics. Next step is to abstract and generalize those patterns, to allow for potentially arbitrary `psutil` metrics to be tracked. Third step is to begin to allow the metrics which are tracked to be controlled via the configurations/settings file.

Using these it should soon be possible to track network i/o with NBResuse, compare the [`psutil` documentation](https://psutil.readthedocs.io/en/latest/).

For system-wide metrics, psutil offers the categories of:

- CPU metrics
- Memory metrics
- Disk metrics
- Network metrics
- Sensor metrics
- Boot time and users (not sure if want/need to include that via NBResuse, but we maybe could)

For process-specific metrics, `psutil` offers the categories of:

- I/O counters
- File descriptors (Unix)
- handles (Windows)
- threads
- CPU (cpu_times, cpu_percent
- Memory (memory_info, memory_full_info, memory_percent)

By limiting the scope of what NBResuse attempts to support only to metrics which are (1) cross-platform, and which (2) correspond to either a numerical return value or a numerical attribute of a named tuple return value, this might be feasible+maintainable.