### PR TITLE
Adding support for jupyterlab statusbar-extension #36

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We recommend using [pipenv](https://docs.pipenv.org/) to make development easier
    ```
 
 2. Create an environment that will hold our dependencies.
-   
+
    ```bash
    cd nbresuse
    pipenv --python 3.6
@@ -32,10 +32,8 @@ We recommend using [pipenv](https://docs.pipenv.org/) to make development easier
 4. Do a dev install of nbresuse and its dependencies
 
    ```bash
-   pip install --editable .[resources]
+   pip install --editable .[dev]
    ```
-
-   To test the behavior of NBResuse without `psutil` installed, run `pip install --editable .` instead.
 
 5. Install and enable the nbextension for use with Jupyter Classic Notebook.
 
@@ -73,7 +71,7 @@ the pre-commit hook should take care of how it should look. Here is how to set u
     ```bash
     pre-commit run
     ```
-	
+
 which should run any autoformatting on your code
 and tell you about any errors it couldn't fix automatically.
 You may also install [black integration](https://github.com/ambv/black#editor-integration)

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ main toolbar in the notebook itself, refreshing every 5s.
 You can currently install this package from PyPI.
 
 ```bash
-pip install nbresuse[resources]
+pip install nbresuse
 ```
-
-The above command will install NBResuse along with `psutil` Python package (which is used for getting hardware usage information from the system). If you would like to install NBResuse _without_ `psutil` (in which case NBResuse does essentially nothing), run `pip install nbresuse` instead.
 
 **If your notebook version is < 5.3**, you need to enable the extension manually.
 

--- a/nbresuse/__init__.py
+++ b/nbresuse/__init__.py
@@ -36,11 +36,7 @@ def load_jupyter_server_extension(nbapp):
     nbapp.web_app.settings["nbresuse_display_config"] = resuseconfig
     base_url = nbapp.web_app.settings["base_url"]
     nbapp.web_app.add_handlers(
-        ".*",
-        [
-            (url_path_join(base_url, "/api/nbresuse/v1"), ApiHandler),
-            (url_path_join(base_url, "/metrics"), ApiHandler),
-        ],
+        ".*", [(url_path_join(base_url, "/metrics"), ApiHandler)]
     )
     callback = ioloop.PeriodicCallback(
         PrometheusHandler(PSUtilMetricsLoader(nbapp)), 1000

--- a/nbresuse/__init__.py
+++ b/nbresuse/__init__.py
@@ -1,5 +1,7 @@
+from notebook.utils import url_path_join
 from tornado import ioloop
 
+from nbresuse.api import ApiHandler
 from nbresuse.config import ResourceUseDisplay
 from nbresuse.metrics import PSUtilMetricsLoader
 from nbresuse.prometheus import PrometheusHandler
@@ -32,6 +34,8 @@ def load_jupyter_server_extension(nbapp):
     """
     resuseconfig = ResourceUseDisplay(parent=nbapp)
     nbapp.web_app.settings["nbresuse_display_config"] = resuseconfig
+    route_pattern = url_path_join(nbapp.web_app.settings['base_url'], '/api/nbresuse/v1')
+    nbapp.web_app.add_handlers('.*', [(route_pattern, ApiHandler)])
     callback = ioloop.PeriodicCallback(
         PrometheusHandler(PSUtilMetricsLoader(nbapp)), 1000
     )

--- a/nbresuse/__init__.py
+++ b/nbresuse/__init__.py
@@ -34,8 +34,14 @@ def load_jupyter_server_extension(nbapp):
     """
     resuseconfig = ResourceUseDisplay(parent=nbapp)
     nbapp.web_app.settings["nbresuse_display_config"] = resuseconfig
-    route_pattern = url_path_join(nbapp.web_app.settings['base_url'], '/api/nbresuse/v1')
-    nbapp.web_app.add_handlers('.*', [(route_pattern, ApiHandler)])
+    base_url = nbapp.web_app.settings["base_url"]
+    nbapp.web_app.add_handlers(
+        ".*",
+        [
+            (url_path_join(base_url, "/api/nbresuse/v1"), ApiHandler),
+            (url_path_join(base_url, "/metrics"), ApiHandler),
+        ],
+    )
     callback = ioloop.PeriodicCallback(
         PrometheusHandler(PSUtilMetricsLoader(nbapp)), 1000
     )

--- a/nbresuse/api.py
+++ b/nbresuse/api.py
@@ -1,0 +1,52 @@
+import json
+
+from notebook.base.handlers import IPythonHandler
+from tornado import web
+
+try:
+    # since psutil is an optional dependency
+    import psutil
+except ImportError:
+    psutil = None
+
+try:
+    # Traitlets >= 4.3.3
+    from traitlets import Callable
+except ImportError:
+    from .utils import Callable
+
+
+class ApiHandler(IPythonHandler):
+
+    @web.authenticated
+    async def get(self):
+        """
+        Calculate and return current resource usage metrics
+        """
+        config = self.settings['nbresuse_display_config']
+
+        if psutil:
+            cur_process = psutil.Process()
+            all_processes = [cur_process] + cur_process.children(recursive=True)
+
+            # Get memory information
+            rss = sum([p.memory_info().rss for p in all_processes])
+
+            if callable(config.mem_limit):
+                mem_limit = config.mem_limit(rss=rss)
+            else:  # mem_limit is an Int
+                mem_limit = config.mem_limit
+
+            limits = {'memory': {
+                'rss': mem_limit
+            }}
+            if config.mem_limit:
+                limits['memory']['warn'] = (mem_limit - rss) < (
+                        mem_limit * config.mem_warning_threshold)
+
+            metrics = {
+                'rss': rss,
+                'limits': limits,
+            }
+
+            self.write(json.dumps(metrics))

--- a/nbresuse/api.py
+++ b/nbresuse/api.py
@@ -1,8 +1,10 @@
 import json
+from concurrent.futures import ThreadPoolExecutor
 
 import psutil
 from notebook.base.handlers import IPythonHandler
 from tornado import web
+from tornado.concurrent import run_on_executor
 
 try:
     # Traitlets >= 4.3.3
@@ -12,6 +14,9 @@ except ImportError:
 
 
 class ApiHandler(IPythonHandler):
+
+    executor = ThreadPoolExecutor(max_workers=5)
+
     @web.authenticated
     async def get(self):
         """
@@ -38,4 +43,30 @@ class ApiHandler(IPythonHandler):
 
         metrics = {"rss": rss, "limits": limits}
 
+        # Optionally get CPU information
+        if config.track_cpu_percent:
+            cpu_count = psutil.cpu_count()
+            cpu_percent = await self._get_cpu_percent(all_processes)
+
+            if config.cpu_limit != 0:
+                limits["cpu"] = {"cpu": config.cpu_limit}
+                if config.cpu_warning_threshold != 0:
+                    limits["cpu"]["warn"] = (config.cpu_limit - self.cpu_percent) < (
+                        config.cpu_limit * config.cpu_warning_threshold
+                    )
+
+            metrics.update(cpu_percent=cpu_percent, cpu_count=cpu_count)
+
         self.write(json.dumps(metrics))
+
+    @run_on_executor
+    def _get_cpu_percent(self, all_processes):
+        def get_cpu_percent(p):
+            try:
+                return p.cpu_percent(interval=0.05)
+            # Avoid littering logs with stack traces complaining
+            # about dead processes having no CPU usage
+            except:
+                return 0
+
+        return sum([get_cpu_percent(p) for p in all_processes])

--- a/nbresuse/api.py
+++ b/nbresuse/api.py
@@ -1,13 +1,8 @@
 import json
 
+import psutil
 from notebook.base.handlers import IPythonHandler
 from tornado import web
-
-try:
-    # since psutil is an optional dependency
-    import psutil
-except ImportError:
-    psutil = None
 
 try:
     # Traitlets >= 4.3.3
@@ -17,36 +12,30 @@ except ImportError:
 
 
 class ApiHandler(IPythonHandler):
-
     @web.authenticated
     async def get(self):
         """
         Calculate and return current resource usage metrics
         """
-        config = self.settings['nbresuse_display_config']
+        config = self.settings["nbresuse_display_config"]
 
-        if psutil:
-            cur_process = psutil.Process()
-            all_processes = [cur_process] + cur_process.children(recursive=True)
+        cur_process = psutil.Process()
+        all_processes = [cur_process] + cur_process.children(recursive=True)
 
-            # Get memory information
-            rss = sum([p.memory_info().rss for p in all_processes])
+        # Get memory information
+        rss = sum([p.memory_info().rss for p in all_processes])
 
-            if callable(config.mem_limit):
-                mem_limit = config.mem_limit(rss=rss)
-            else:  # mem_limit is an Int
-                mem_limit = config.mem_limit
+        if callable(config.mem_limit):
+            mem_limit = config.mem_limit(rss=rss)
+        else:  # mem_limit is an Int
+            mem_limit = config.mem_limit
 
-            limits = {'memory': {
-                'rss': mem_limit
-            }}
-            if config.mem_limit:
-                limits['memory']['warn'] = (mem_limit - rss) < (
-                        mem_limit * config.mem_warning_threshold)
+        limits = {"memory": {"rss": mem_limit}}
+        if config.mem_limit:
+            limits["memory"]["warn"] = (mem_limit - rss) < (
+                mem_limit * config.mem_warning_threshold
+            )
 
-            metrics = {
-                'rss': rss,
-                'limits': limits,
-            }
+        metrics = {"rss": rss, "limits": limits}
 
-            self.write(json.dumps(metrics))
+        self.write(json.dumps(metrics))

--- a/nbresuse/static/main.js
+++ b/nbresuse/static/main.js
@@ -34,7 +34,7 @@ define([
             return;
         }
         $.getJSON({
-            url: utils.get_body_data('baseUrl') + 'api/nbresuse/v1',
+            url: utils.get_body_data('baseUrl') + 'metrics',
             success: function (data) {
                 totalMemoryUsage = humanFileSize(data['rss']);
 

--- a/nbresuse/static/main.js
+++ b/nbresuse/static/main.js
@@ -44,7 +44,7 @@ define([
                 if (limits['memory']) {
                     if (limits['memory']['rss']) {
                         maxMemoryUsage = humanFileSize(limits['memory']['rss']);
-                        display += "/" + maxMemoryUsage
+                        display += " / " + maxMemoryUsage
                     }
                     if (limits['memory']['warn']) {
                         $('#nbresuse-display').addClass('nbresuse-warn');

--- a/nbresuse/tests/test_basic.py
+++ b/nbresuse/tests/test_basic.py
@@ -25,7 +25,7 @@ class TestBasic:
 
         # mock a notebook app
         nbapp_mock = MagicMock()
-        nbapp_mock.web_app.settings = {}
+        nbapp_mock.web_app.settings = {"base_url": ""}
 
         # mock these out for unit test
         with patch("tornado.ioloop.PeriodicCallback") as periodic_callback_mock, patch(

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,9 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
     ],
     packages=setuptools.find_packages(),
-    install_requires=["notebook>=5.6.0", "prometheus_client"],
-    extras_require={
-        "resources": ["psutil>=5.6.0"],
-        "dev": ["autopep8", "black", "pytest", "flake8", "pytest-cov>=2.6.1", "mock"],
+    install_requires=["notebook>=5.6.0", "prometheus_client", "psutil>=5.6.0"],
+    extres_require={
+        "dev": ["autopep8", "black", "pytest", "flake8", "pytest-cov>=2.6.1", "mock"]
     },
     data_files=[
         ("share/jupyter/nbextensions/nbresuse", glob("nbresuse/static/*")),

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
     name="nbresuse",
-    version="0.4.0",
+    version="0.3.4",
     url="https://github.com/yuvipanda/nbresuse",
     author="Yuvi Panda",
     description="Simple Jupyter extension to show how much resources (RAM) your notebook is using",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     install_requires=["notebook>=5.6.0", "prometheus_client", "psutil>=5.6.0"],
-    extres_require={
+    extras_require={
         "dev": ["autopep8", "black", "pytest", "flake8", "pytest-cov>=2.6.1", "mock"]
     },
     data_files=[


### PR DESCRIPTION
This solves yuvipanda#36

Have to raise PR on jupyterlab statusbar-extension to change api call to /api/nbresuse/v1 once this PR is merged.

Once this is done, then we can merge yuvipanda#41 and release a new version to PyPi.

- [x] Add back `psutil` as a dependency
- [x] Add back the `/metrics` endpoint with mem and cpu usage