### PR TITLE
Fix pre-commit, extend gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ var/
 .installed.cfg
 *.egg
 *.ipynb
+
+# IDE and code editors
+*.iml
+.idea
+.vscode
+*.code-workspace
+.history

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v1.3.5
   hooks:
   - id: reorder-python-imports
-    language_version: python3.6
+    language_version: python3
 - repo: https://github.com/ambv/black
   rev: 18.9b0
   hooks:


### PR DESCRIPTION
Add a couple of extra files to exclude in the gitignore.

Also fixing the pre-commit hook so it doesn't fail locally with other versions of Python than 3.6.