### PR TITLE
determine if nbresuse is running in docker or pod

### DIFF
--- a/nbresuse/api.py
+++ b/nbresuse/api.py
@@ -5,6 +5,7 @@ import psutil
 from notebook.base.handlers import IPythonHandler
 from tornado import web
 from tornado.concurrent import run_on_executor
+import os
 
 try:
     # Traitlets >= 4.3.3


### PR DESCRIPTION
Returns the correct memory & cpu values when nbresuse running in a docker or pod environment